### PR TITLE
Show unverified signatures

### DIFF
--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -833,10 +833,12 @@ class WidgetAnnotation extends Annotation {
     // Hide signatures because we cannot validate them, and unset the fieldValue
     // since it's (most likely) a `Dict` which is non-serializable and will thus
     // cause errors when sending annotations to the main-thread (issue 10347).
-    if (data.fieldType === "Sig") {
-      data.fieldValue = null;
-      this.setFlags(AnnotationFlag.HIDDEN);
-    }
+    //
+    // UPDATE: Comment this, show the signatures anyway
+    // if (data.fieldType === "Sig") {
+    //   data.fieldValue = null;
+    //   this.setFlags(AnnotationFlag.HIDDEN);
+    // }
   }
 
   /**


### PR DESCRIPTION
This fix https://github.com/mozilla/pdf.js/issues/10347 leads to some of signatures are not shown on pdf. 
Show signatures anyway, it is more important than broken annotations.